### PR TITLE
Decouple VR presentation

### DIFF
--- a/Source/Core/VideoBackends/D3D/D3DGfx.cpp
+++ b/Source/Core/VideoBackends/D3D/D3DGfx.cpp
@@ -195,13 +195,8 @@ void Gfx::PresentBackbuffer()
     // Changed log type to VR
     INFO_LOG_FMT(VR, "Gfx::PresentBackbuffer (VR Path)");
 
-    // Submit frames to HMD
-    if (!m_vrd3d->SubmitFrames())
-    {
-      // Changed log type to VR
-      ERROR_LOG_FMT(VR, "Gfx::PresentBackbuffer: Failed to submit frames to OpenVR.");
-      // Potentially handle this error, e.g., by stopping VR mode.
-    }
+    // Signal VR thread that a frame is ready for submission
+    m_vrd3d->NotifyFrameReady();
 
     // TODO: Optionally render a companion view to the main swap chain.
     // For now, just present whatever is on the swap chain (likely nothing or a cleared screen).

--- a/Source/Core/VideoBackends/D3D/VRD3D.cpp
+++ b/Source/Core/VideoBackends/D3D/VRD3D.cpp
@@ -8,6 +8,7 @@
 #include "VideoCommon/VROpenVR.h"
 #include "Common/Logging/Log.h"
 #include <Common/Assert.h>
+#include <chrono>
 
 VRD3D::VRD3D(VROpenVR* vr_system, ID3D11Device* d3d_device)
     : m_vr_system(vr_system),
@@ -22,6 +23,12 @@ VRD3D::VRD3D(VROpenVR* vr_system, ID3D11Device* d3d_device)
 
 VRD3D::~VRD3D()
 {
+  m_running = false;
+  if (m_presentation_thread.joinable())
+  {
+    m_frame_cv.notify_all();
+    m_presentation_thread.join();
+  }
   // Resources should be released by ComPtr and unique_ptr automatically.
   m_initialized = false;
 }
@@ -108,6 +115,10 @@ bool VRD3D::Init()
 
   m_initialized = true;
   INFO_LOG_FMT(VR, "VRD3D initialized successfully with eye framebuffers and textures.");
+
+  m_running = true;
+  m_presentation_thread = std::thread(&VRD3D::PresentationLoop, this);
+
   return true;
 }
 
@@ -130,23 +141,7 @@ bool VRD3D::SubmitFrames()
     return false;
   }
 
-  // Call WaitGetPoses before submitting frames.
-  // This is crucial for synchronization and for the compositor to be ready.
-  vr::EVRCompositorError wait_error = m_vr_system->GetCompositor()->WaitGetPoses(m_tracked_device_pose, vr::k_unMaxTrackedDeviceCount, nullptr, 0);
-  if (wait_error != vr::VRCompositorError_None)
-  {
-    ERROR_LOG_FMT(VR, "VRD3D::SubmitFrames - WaitGetPoses failed with error: {}", static_cast<int>(wait_error));
-    // Depending on the error, we might still try to submit, or return false.
-    // For now, let's try to submit anyway, but log the error.
-    // If it's VRCompositorError_RequestFailed, submit will likely also fail.
-  }
-  else
-  {
-    INFO_LOG_FMT(VR, "VRD3D::SubmitFrames - WaitGetPoses successful.");
-  }
-  // TODO: The poses in m_tracked_device_pose should ideally be used for rendering the frame.
-  // Currently, VROpenVR::GetHMDPose uses GetDeviceToAbsoluteTrackingPose.
-  // For now, we're just ensuring WaitGetPoses is called.
+
 
   ID3D11Texture2D* left_tex_ptr = m_left_eye_d3d_texture_for_submit.Get();
   ID3D11Texture2D* right_tex_ptr = m_right_eye_d3d_texture_for_submit.Get();
@@ -197,6 +192,45 @@ bool VRD3D::SubmitFrames()
   // D3D::context->Flush(); // Recommended by OpenVR docs after submit if not using explicit timing.
 
   return error_left == vr::VRCompositorError_None && error_right == vr::VRCompositorError_None;
+}
+
+void VRD3D::NotifyFrameReady()
+{
+  {
+    std::lock_guard<std::mutex> lk(m_frame_mutex);
+    m_frame_ready = true;
+  }
+  m_frame_cv.notify_one();
+}
+
+void VRD3D::PresentationLoop()
+{
+  while (m_running)
+  {
+    if (!m_vr_system || !m_vr_system->GetCompositor())
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      continue;
+    }
+
+    vr::EVRCompositorError wait_error =
+        m_vr_system->GetCompositor()->WaitGetPoses(m_tracked_device_pose,
+                                                   vr::k_unMaxTrackedDeviceCount,
+                                                   nullptr, 0);
+    if (wait_error != vr::VRCompositorError_None)
+    {
+      ERROR_LOG_FMT(VR, "VRD3D::PresentationLoop - WaitGetPoses error: {}",
+                    static_cast<int>(wait_error));
+    }
+
+    std::unique_lock<std::mutex> lk(m_frame_mutex);
+    m_frame_cv.wait(lk, [this] { return !m_running || m_frame_ready; });
+    if (!m_running)
+      break;
+    m_frame_ready = false;
+    SubmitFrames();
+    lk.unlock();
+  }
 }
 
 DX11::DXTexture* VRD3D::GetLeftEyeTexture()

--- a/Source/Core/VideoBackends/D3D/VRD3D.h
+++ b/Source/Core/VideoBackends/D3D/VRD3D.h
@@ -7,6 +7,9 @@
 #include <openvr.h> // For vr::VRCompositorError, vr::Texture_t, vr::VRTextureBounds_t
 #include <d3d11.h>    // For D3D11 types
 #include <wrl/client.h> // For ComPtr
+#include <thread>
+#include <mutex>
+#include <condition_variable>
 
 #include "Common/Matrix.h"
 #include "VideoCommon/AbstractTexture.h"
@@ -26,6 +29,9 @@ public:
 
   // Submits the rendered eye textures to the HMD
   bool SubmitFrames();
+
+  // Signal that a new frame is ready for submission
+  void NotifyFrameReady();
 
   // Getters for eye textures (which are D3D render targets)
   // Getters for eye textures (which are D3D render targets)
@@ -63,4 +69,12 @@ private:
 
   vr::TrackedDevicePose_t m_tracked_device_pose[vr::k_unMaxTrackedDeviceCount];
   bool m_initialized = false;
+
+  // VR presentation thread management
+  void PresentationLoop();
+  std::thread m_presentation_thread;
+  std::mutex m_frame_mutex;
+  std::condition_variable m_frame_cv;
+  bool m_running = false;
+  bool m_frame_ready = false;
 };


### PR DESCRIPTION
## Summary
- add a VR presentation thread to avoid blocking the GPU thread
- submit frames to OpenVR from the new thread
- signal the presentation thread from the rendering code

## Testing
- `cmake -B build -S .` *(fails: Package 'xi' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861fa3a96648321b86ea6c66d18e129