### PR TITLE
Integrate VR-Hydra core components into VR-Reloaded-3

### DIFF
--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -38,6 +38,7 @@
 #include "Common/Logging/Log.h"
 #include "Common/MsgHandler.h"
 
+#include "Core/ARBruteForcer.h" // Added for VR brute-forcer
 #include "Core/ARDecrypt.h"
 #include "Core/AchievementManager.h"
 #include "Core/CheatCodes.h"
@@ -995,19 +996,101 @@ static bool RunCodeLocked(const Core::CPUThreadGuard& guard, const ARCode& arcod
 
 void RunAllActive(const Core::CPUThreadGuard& cpu_guard)
 {
-  if (!Config::AreCheatsEnabled())
+  // Check if any codes (normal cheats or brute-forcer) need to be run.
+  // Brute-forcer can run even if general cheats are disabled.
+  bool should_run_bruteforcer = ARBruteForcer::ch_bruteforce && ARBruteForcer::ch_begun &&
+                                ARBruteForcer::ch_current_position > -1 &&
+                                static_cast<size_t>(ARBruteForcer::ch_current_position) < ARBruteForcer::ch_map.size();
+
+  if (!Config::AreCheatsEnabled() && !should_run_bruteforcer)
     return;
 
-  // If the mutex is idle then acquiring it should be cheap, fast mutexes
-  // are only atomic ops unless contested. It should be rare for this to
-  // be contested.
-  std::lock_guard guard(s_lock);
-  std::erase_if(s_active_codes, [&cpu_guard](const ARCode& code) {
-    const bool success = RunCodeLocked(cpu_guard, code);
-    LogInfo("\n");
-    return !success;
-  });
-  s_disable_logging = true;
+  std::lock_guard guard(s_lock); // Lock for the entire duration of AR operations
+
+  // penkamaster's Action Replay culling code brute-forcing (VR-Hydra addition)
+  if (should_run_bruteforcer)
+  {
+    WARN_LOG_FMT(ACTIONREPLAY, "Applying brute-forcer temporary culling code");
+    ARCode ch_currentCode;
+
+    ch_currentCode.enabled = true;
+    ch_currentCode.name = "temporary_culling_code";
+    ch_currentCode.user_defined = true;
+
+    AREntry op1, op2;
+    bool success_addr1, success_val1, success_addr2, success_val2;
+
+    std::string addr_str_op1 = ARBruteForcer::ch_map[ARBruteForcer::ch_current_position];
+    std::string val_str1 = "3860000" + ARBruteForcer::ch_code;
+    success_addr1 = TryParse(addr_str_op1, &op1.cmd_addr, 16);
+    success_val1 = TryParse(val_str1, &op1.value, 16);
+
+    if (success_addr1 && success_val1)
+    {
+      ch_currentCode.ops.push_back(op1);
+    }
+    else
+    {
+      ERROR_LOG_FMT(ACTIONREPLAY, "Failed to parse brute-forcer AR code (op1): addr_str='{}', val_str='{}'",
+                    addr_str_op1, val_str1);
+    }
+
+    u32 original_addr_op2_val;
+    if (TryParse(addr_str_op1, &original_addr_op2_val, 16))
+    {
+      u32 new_addr_op2_val = original_addr_op2_val + 4;
+      std::stringstream temp_stream_hex_addr;
+      temp_stream_hex_addr << std::hex << new_addr_op2_val;
+      std::string new_addr_op2_str = temp_stream_hex_addr.str();
+
+      success_addr2 = TryParse(new_addr_op2_str, &op2.cmd_addr, 16);
+      success_val2 = TryParse("4E800020", &op2.value, 16);
+
+      if (success_addr2 && success_val2)
+      {
+        ch_currentCode.ops.push_back(op2);
+      }
+      else
+      {
+        ERROR_LOG_FMT(ACTIONREPLAY, "Failed to parse brute-forcer AR code (op2): addr_str='{}', val_str='4E800020'",
+                      new_addr_op2_str);
+      }
+    }
+    else
+    {
+      ERROR_LOG_FMT(ACTIONREPLAY, "Failed to parse original address for brute-forcer op2: '{}'",
+                    addr_str_op1);
+    }
+
+    if (ch_currentCode.ops.size() == 2) // Expecting two operations
+    {
+      const bool success = RunCodeLocked(cpu_guard, ch_currentCode);
+      if (success)
+      {
+        INFO_LOG_FMT(ACTIONREPLAY, "Brute-forcer temporary code applied successfully.");
+      }
+      else
+      {
+        ERROR_LOG_FMT(ACTIONREPLAY, "Brute-forcer temporary code failed to apply.");
+      }
+    }
+    else
+    {
+      WARN_LOG_FMT(ACTIONREPLAY, "Brute-forcer code ops vector size was {}, expected 2. Code not applied.", ch_currentCode.ops.size());
+    }
+  }
+
+  // Apply regular active cheat codes if cheats are enabled
+  if (Config::AreCheatsEnabled())
+  {
+    std::erase_if(s_active_codes, [&cpu_guard](const ARCode& code) {
+      const bool success = RunCodeLocked(cpu_guard, code);
+      LogInfo("\n"); // Log a newline after each code's output
+      return !success; // Remove if not successful
+    });
+  }
+
+  s_disable_logging = true; // Disable logging after all codes for the frame are processed
 }
 
 }  // namespace ActionReplay

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -93,13 +93,41 @@ SConfig::~SConfig()
 void SConfig::SaveSettings()
 {
   NOTICE_LOG_FMT(BOOT, "Saving settings to {}", File::GetUserPath(F_DOLPHINCONFIG_IDX));
-  Config::Save();
+  Config::Save(); // Saves settings managed by the Common::Config system
+
+  // Manually save VR-specific settings directly to Dolphin.ini
+  // This is a simplified approach due to uncertainty about the new Config registration.
+  Common::IniFile ini_file;
+  ini_file.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
+
+  Common::IniFile::Section* vr_section = ini_file.GetOrCreateSection("VR");
+  vr_section->Set("AsynchronousTimewarp", bAsynchronousTimewarp);
+  vr_section->Set("BruteforceScreenshotAll", m_BruteforceScreenshotAll);
+  vr_section->Set("OriginalPrimitiveCount", m_OriginalPrimitiveCount);
+
+  // ShowVRStateColumn was in GameList section in Hydra, let's try to keep it there.
+  Common::IniFile::Section* gamelist_section = ini_file.GetOrCreateSection("GameList");
+  gamelist_section->Set("ColumnVRState", m_showVRStateColumn);
+
+  ini_file.Save(File::GetUserPath(F_DOLPHINCONFIG_IDX));
 }
 
 void SConfig::LoadSettings()
 {
   INFO_LOG_FMT(BOOT, "Loading Settings from {}", File::GetUserPath(F_DOLPHINCONFIG_IDX));
-  Config::Load();
+  Config::Load(); // Loads settings managed by the Common::Config system
+
+  // Manually load VR-specific settings directly from Dolphin.ini
+  Common::IniFile ini_file;
+  ini_file.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
+
+  Common::IniFile::Section* vr_section = ini_file.GetOrCreateSection("VR");
+  vr_section->Get("AsynchronousTimewarp", &bAsynchronousTimewarp, false);
+  vr_section->Get("BruteforceScreenshotAll", &m_BruteforceScreenshotAll, false);
+  vr_section->Get("OriginalPrimitiveCount", &m_OriginalPrimitiveCount, -1);
+
+  Common::IniFile::Section* gamelist_section = ini_file.GetOrCreateSection("GameList");
+  gamelist_section->Get("ColumnVRState", &m_showVRStateColumn, true);
 }
 
 const std::string SConfig::GetGameID() const
@@ -308,6 +336,12 @@ void SConfig::LoadDefaults()
   auto& system = Core::System::GetInstance();
   system.SetIsWii(false);
   system.SetIsTriforce(false);
+
+  // Initialize VR settings to defaults
+  bAsynchronousTimewarp = false;
+  m_BruteforceScreenshotAll = false;
+  m_OriginalPrimitiveCount = -1;
+  m_showVRStateColumn = true;
 
   ResetRunningGameMetadata();
 }

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -70,6 +70,13 @@ struct SConfig
   std::string GetTriforceID() const;
   u64 GetTitleID() const;
   u16 GetRevision() const;
+
+  // VR Settings
+  bool bAsynchronousTimewarp = false;
+  bool m_BruteforceScreenshotAll = false;
+  int m_OriginalPrimitiveCount = -1;
+  bool m_showVRStateColumn = true; // For GameList
+
   void ResetRunningGameMetadata();
   void SetRunningGameMetadata(const DiscIO::Volume& volume, const DiscIO::Partition& partition);
   void SetRunningGameMetadata(const IOS::ES::TMDReader& tmd, DiscIO::Platform platform);

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -41,9 +41,11 @@
 #include "Core/BootManager.h"
 #include "Core/CPUThreadConfigCallback.h"
 #include "Core/Config/MainSettings.h"
+#include "Core/ARBruteForcer.h" // For KillDolphinAndRestart
 #include "Core/ConfigManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/DSPEmulator.h"
+#include "VideoCommon/VR.h" // For VR::Init
 #include "Core/DolphinAnalytics.h"
 #include "Core/FifoPlayer/FifoPlayer.h"
 #include "Core/FreeLookManager.h"
@@ -253,6 +255,7 @@ bool Init(Core::System& system, std::unique_ptr<BootParameters> boot, const Wind
   // Start the emu thread
   s_state.store(State::Starting);
   s_emu_thread = std::thread(EmuThread, std::ref(system), std::move(boot), prepared_wsi);
+
   return true;
 }
 
@@ -561,6 +564,17 @@ static void EmuThread(Core::System& system, std::unique_ptr<BootParameters> boot
     PanicAlertFmt("Failed to initialize video backend!");
     return;
   }
+
+  // Initialize VR system now that the video backend is ready.
+  if (!VR::Init(system, wsi)) // Assuming VR::Init(Core::System& system, const WindowSystemInfo& wsi) signature
+  {
+    // Decide if VR initialization failure is fatal or just disables VR features.
+    // For now, treating as fatal to match typical hardware init failures.
+    PanicAlertFmt("Failed to initialize VR system!");
+    // Ensure video_guard and other guards run by returning.
+    return;
+  }
+
   Common::ScopeGuard video_guard{[] {
     // Clear on screen messages that haven't expired
     OSD::ClearMessages();
@@ -1062,6 +1076,69 @@ CPUThreadGuard::~CPUThreadGuard()
 {
   if (!m_was_cpu_thread)
     PauseAndLock(m_system, false, m_was_unpaused);
+}
+
+void KillDolphinAndRestart()
+{
+  // If it's the first time through and it crashes on the first function, we must advance the
+  // position.
+  if (ARBruteForcer::ch_bruteforce &&
+      (ARBruteForcer::ch_begin_search || ARBruteForcer::ch_first_search))
+    ARBruteForcer::IncrementPositionTxt();
+
+#if defined _WIN32
+  // Restart Dolphin automatically after fatal crash.
+  PROCESS_INFORMATION ProcessInfo;
+  STARTUPINFO StartupInfo;
+
+  ZeroMemory(&StartupInfo, sizeof(StartupInfo));
+  StartupInfo.cb = sizeof StartupInfo;  // Only compulsory field
+  ZeroMemory(&ProcessInfo, sizeof(ProcessInfo));
+
+  // Get current executable path
+  char current_exe_path[MAX_PATH];
+  GetModuleFileNameA(nullptr, current_exe_path, MAX_PATH);
+
+  std::string command_line = "\"" + std::string(current_exe_path) + "\"";
+
+  if (ARBruteForcer::ch_bruteforce)
+  {
+    if (ARBruteForcer::ch_code == "0")
+    {
+      command_line += " -bruteforce 0";
+    }
+    else if (ARBruteForcer::ch_code == "1")
+    {
+      command_line += " -bruteforce 1";
+    }
+    else
+    {
+      // This case was a PanicAlert in Hydra, which isn't ideal for an agent.
+      // Log an error and proceed with termination. The user will see the error.
+      ERROR_LOG_FMT(CORE, "Bruteforcer restart with ch_code '{}' not automatically handled. Terminating.", ARBruteForcer::ch_code);
+      TerminateProcess(GetCurrentProcess(), 1); // Indicate error
+      return; // Should not be reached
+    }
+  }
+
+  // Need to convert std::string to LPSTR (non-const char*)
+  // CreateProcess modifies the string.
+  std::vector<char> cmd_line_vec(command_line.begin(), command_line.end());
+  cmd_line_vec.push_back('\0'); // Null-terminate
+
+  if (!CreateProcessA(nullptr, cmd_line_vec.data(), nullptr, nullptr, false, NORMAL_PRIORITY_CLASS, nullptr,
+                     nullptr, &StartupInfo, &ProcessInfo))
+  {
+    DWORD error = GetLastError();
+    ERROR_LOG_FMT(CORE, "Failed to restart Dolphin.exe. CreateProcess error: {}. Terminating.", error);
+  }
+
+  TerminateProcess(GetCurrentProcess(), 0); // 0 for success as restart was attempted
+#else
+  // Non-Windows: Log and exit. Automatic restart is more complex.
+  ERROR_LOG_FMT(CORE, "KillDolphinAndRestart: Automatic restart is not implemented for this platform. Terminating.");
+  std::exit(1); // Exit with an error code
+#endif
 }
 
 }  // namespace Core

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -121,6 +121,7 @@ private:
 bool Init(Core::System& system, std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi);
 void Stop(Core::System& system);
 void Shutdown(Core::System& system);
+void KillDolphinAndRestart(); // Added for ARBruteForcer recovery
 
 void DeclareAsCPUThread();
 void UndeclareAsCPUThread();

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -185,6 +185,10 @@ void MovieManager::FrameUpdate()
   }
 
   m_polled = false;
+
+  // Perform frame skipping logic if active
+  if (m_frames_to_skip > 0) // Only call if skipping is potentially active
+    PerformFrameSkippingLogic();
 }
 
 // called when game is booting up, even if no movie is active,
@@ -1525,4 +1529,62 @@ void MovieManager::Shutdown()
   m_current_input_count = m_total_input_count = m_total_frames = m_tick_count_at_last_input = 0;
   m_temp_input.clear();
 }
+
+void MovieManager::SetFrameSkipping(unsigned int frames_to_skip)
+{
+  std::lock_guard guard(m_frame_skip_mutex);
+  m_frames_to_skip = frames_to_skip;
+  m_frame_skip_counter = 0; // Reset counter when skip value changes
+
+  // If frame skipping is turned off, ensure rendering is enabled.
+  if (m_frames_to_skip == 0)
+  {
+    if (Core::IsRunning(m_system)) // Only touch FIFO if emulation is running
+      m_system.GetFifo().SetRendering(true);
+  }
+}
+
+void MovieManager::PerformFrameSkippingLogic()
+{
+  // Frame skipping should not interfere with deterministic recordings/playback
+  if (Core::WantsDeterminism())
+  {
+    // If we want determinism but frame skipping was somehow enabled, disable it and ensure rendering.
+    if (m_frames_to_skip > 0)
+    {
+        std::lock_guard guard(m_frame_skip_mutex);
+        m_frames_to_skip = 0;
+        m_frame_skip_counter = 0;
+        if (Core::IsRunning(m_system))
+            m_system.GetFifo().SetRendering(true);
+    }
+    return;
+  }
+
+  std::lock_guard guard(m_frame_skip_mutex);
+
+  if (m_frames_to_skip == 0) // Should not be called if m_frames_to_skip is 0, but as a safe guard.
+  {
+    if (Core::IsRunning(m_system))
+        m_system.GetFifo().SetRendering(true);
+    return;
+  }
+
+  m_frame_skip_counter++;
+  bool render_this_frame = false;
+
+  // This is where Core::ShouldSkipFrame would have been.
+  // That function compared actual performance against target FPS.
+  // For VR, the primary need is to *force* skipping or *force no* skipping.
+  // A simple implementation: skip N frames, then render 1.
+  if (m_frame_skip_counter > m_frames_to_skip)
+  {
+    render_this_frame = true;
+    m_frame_skip_counter = 0;
+  }
+
+  if (Core::IsRunning(m_system))
+    m_system.GetFifo().SetRendering(render_this_frame);
+}
+
 }  // namespace Movie

--- a/Source/Core/Core/Movie.h
+++ b/Source/Core/Core/Movie.h
@@ -224,7 +224,10 @@ public:
   std::string GetRTCDisplay() const;
   std::string GetRerecords() const;
 
+  void SetFrameSkipping(unsigned int frames_to_skip);
+
 private:
+  void PerformFrameSkippingLogic(); // Helper for frame skipping
   void GetSettings();
   void CheckInputEnd();
 
@@ -272,6 +275,11 @@ private:
   // m_input_display is used by both CPU and GPU (is mutable).
   std::mutex m_input_display_lock;
   std::array<std::string, 8> m_input_display;
+
+  // Frame skipping members
+  std::mutex m_frame_skip_mutex;
+  unsigned int m_frames_to_skip = 0;
+  unsigned int m_frame_skip_counter = 0;
 
   Core::System& m_system;
 };


### PR DESCRIPTION
This commit ports several key components from the VR-Hydra branch to VR-Reloaded-3, laying some of the groundwork for VR feature integration.

Modifications include:

- ActionReplay.cpp: Integrated logic to apply ARBruteForcer generated patches. Adapted to new ActionReplay structure and locking.

- ConfigManager.cpp / .h: Added VR-specific settings (AsynchronousTimewarp, BruteforceScreenshotAll, OriginalPrimitiveCount, ColumnVRState) directly to SConfig. Implemented manual load/save for these settings in Dolphin.ini as a temporary measure due to difficulties locating the new configuration registration system. Hotkey configuration for VR is not yet included.

- Core.cpp / .h:
    - Added KillDolphinAndRestart function for ARBruteForcer crash recovery.
    - Added a call to VR::Init (placeholder for actual VR system initialization) in EmuThread after video backend initialization.
    - The Oculus SDK 0.4.2 specific VRThread for asynchronous timewarp was intentionally not ported, as OpenVR will handle its own reprojection.

- Movie.cpp / .h: Added SetFrameSkipping function to MovieManager, allowing external control over frame skipping, which can be necessary for VR timing. Frame skipping is disabled when Core::WantsDeterminism() is true.

Note: This integration relies on the future availability and correct API of ARBruteForcer.h and VideoCommon/VR.h (for VR::Init). The ConfigManager changes are a simplified approach and may need refactoring once the VR-Reloaded-3 configuration system is fully understood.